### PR TITLE
Update examples for AsteroidThermoPhysicalModels.jl v0.0.7 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ This repository contains example notebooks demonstrating the use of [AsteroidThe
 
 ## Compatibility
 
-These examples are compatible with **AsteroidThermoPhysicalModels.jl v0.0.6**.
+These examples are compatible with **AsteroidThermoPhysicalModels.jl v0.0.7**.
 
 For examples compatible with other versions:
-- v0.0.7: See the [v0.0.7-compatible branch](https://github.com/Astroshaper/Astroshaper-examples/tree/v0.0.7-compatible) (coming soon)
+- v0.0.6: See the [v0.0.6-compatible branch](https://github.com/Astroshaper/Astroshaper-examples/tree/v0.0.6-compatible)
 
 ## Installation
 

--- a/TPM_Didymos/README.md
+++ b/TPM_Didymos/README.md
@@ -15,5 +15,5 @@ julia --project=.
  _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
 |__/                   |
 
-(TPM_Didymos) pkg> add https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl#v0.0.6
+(TPM_Didymos) pkg> add https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl#v0.0.7
 ```

--- a/TPM_Didymos/TPM_Didymos.ipynb
+++ b/TPM_Didymos/TPM_Didymos.ipynb
@@ -38,7 +38,7 @@
     "# Pkg.add(\"Rotations\")\n",
     "# Pkg.add(\"CairoMakie\")\n",
     "\n",
-    "# Pkg.add(url=\"https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl\")"
+    "# Pkg.add(url=\"https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl#v0.0.7\")"
    ]
   },
   {
@@ -94,7 +94,7 @@
     "\n",
     "##= Download SPICE kernels =##\n",
     "for path_kernel in paths_kernel\n",
-    "    url_kernel = \"https://s2e2.cosmos.esa.int/bitbucket/projects/SPICE_KERNELS/repos/hera/raw/kernels/$(path_kernel)\"\n",
+    "    url_kernel = \"https://s2e2.cosmos.esa.int/bitbucket/projects/SPICE_KERNELS/repos/hera/raw/kernels/$(path_kernel)?at=refs%2Ftags%2Fv161_20230929_001\"\n",
     "    filepath = joinpath(\"kernel\", path_kernel)\n",
     "    mkpath(dirname(filepath))\n",
     "    isfile(filepath) || Downloads.download(url_kernel, filepath)\n",
@@ -102,7 +102,7 @@
     "\n",
     "##= Download shape models =##\n",
     "for path_shape in paths_shape\n",
-    "    url_kernel = \"https://s2e2.cosmos.esa.int/bitbucket/projects/SPICE_KERNELS/repos/hera/raw/kernels/dsk/$(path_shape)\"\n",
+    "    url_kernel = \"https://s2e2.cosmos.esa.int/bitbucket/projects/SPICE_KERNELS/repos/hera/raw/kernels/dsk/$(path_shape)?at=refs%2Ftags%2Fv161_20230929_001\"\n",
     "    filepath = joinpath(\"shape\", path_shape)\n",
     "    mkpath(dirname(filepath))\n",
     "    isfile(filepath) || Downloads.download(url_kernel, filepath)\n",
@@ -241,7 +241,61 @@
    "id": "ed1d48a2",
    "metadata": {},
    "source": [
-    "Thermal properties of Didymos and Dimorphos [Michel+2016; Naidu+2020]"
+    "Thermal properties of the primary body, **Didymos** [Michel+2016; Naidu+2020]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6778d12d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "k  = 0.125   # Thermal conductivity [W/m/K]\n",
+    "ρ  = 2170.0  # Density [kg/m³]\n",
+    "Cₚ = 600.0   # Heat capacity at constant pressure [J/kg/K]\n",
+    "\n",
+    "R_vis = 0.059  # Reflectance in visible light [-]\n",
+    "R_ir  = 0.0    # Reflectance in thermal infrared [-]\n",
+    "ε     = 0.9    # Emissivity [-]\n",
+    "\n",
+    "z_max = 0.5                 # Depth of the lower boundary of a heat conduction equation [m]\n",
+    "n_depth = 101               # Number of depth steps\n",
+    "Δz = z_max / (n_depth - 1)  # Depth step width [m]\n",
+    "\n",
+    "thermo_params1 = AsteroidThermoPhysicalModels.ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b55a9fd",
+   "metadata": {},
+   "source": [
+    "Thermal properties of the secondary body, **Dimorphos** [Michel+2016; Naidu+2020]\n",
+    "\n",
+    "Here, the same thermal properties are assigned to the primary and secondary. Different values can also be assigned."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a9525d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "k  = 0.125   # Thermal conductivity [W/m/K]\n",
+    "ρ  = 2170.0  # Density [kg/m³]\n",
+    "Cₚ = 600.0   # Heat capacity at constant pressure [J/kg/K]\n",
+    "\n",
+    "R_vis = 0.059  # Reflectance in visible light [-]\n",
+    "R_ir  = 0.0    # Reflectance in thermal infrared [-]\n",
+    "ε     = 0.9    # Emissivity [-]\n",
+    "\n",
+    "z_max = 0.5                 # Depth of the lower boundary of a heat conduction equation [m]\n",
+    "n_depth = 101               # Number of depth steps\n",
+    "Δz = z_max / (n_depth - 1)  # Depth step width [m]\n",
+    "\n",
+    "thermo_params2 = AsteroidThermoPhysicalModels.ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth);"
    ]
   },
   {
@@ -251,68 +305,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "k  = 0.125   # Thermal conductivity\n",
-    "ρ  = 2170.0  # Material density\n",
-    "Cₚ = 600.0   # Heat capacity at constant pressure\n",
+    "l₁ = AsteroidThermoPhysicalModels.thermal_skin_depth(P₁, k, ρ, Cₚ)  # Thermal skin depth of Didymos [m]\n",
+    "l₂ = AsteroidThermoPhysicalModels.thermal_skin_depth(P₂, k, ρ, Cₚ)  # Thermal skin depth of Dimorphos [m]\n",
+    "Γ = AsteroidThermoPhysicalModels.thermal_inertia(k, ρ, Cₚ)          # Thermal inertia [kg^(1/2) m^(1/2) s^(-1)]\n",
+    "α = AsteroidThermoPhysicalModels.thermal_diffusivity(k, ρ, Cₚ)      # Thermal diffusivity [m²/s]\n",
     "\n",
-    "l₁ = AsteroidThermoPhysicalModels.thermal_skin_depth(P₁, k, ρ, Cₚ)  # Thermal skin depth of Didymos\n",
-    "l₂ = AsteroidThermoPhysicalModels.thermal_skin_depth(P₂, k, ρ, Cₚ)  # Thermal skin depth of Dimorphos\n",
-    "Γ₁ = AsteroidThermoPhysicalModels.thermal_inertia(k, ρ, Cₚ);        # Thermal inertia of Didymos\n",
-    "Γ₂ = AsteroidThermoPhysicalModels.thermal_inertia(k, ρ, Cₚ);        # Thermal inertia of Dimorphos"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8bd41b18",
-   "metadata": {},
-   "source": [
-    "Thermal properties of Didymos "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "54c74610",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "thermo_params1 = AsteroidThermoPhysicalModels.thermoparams(\n",
-    "    P       = P₁,     # Rotation period\n",
-    "    l       = l₁,     # Thermal skin depth\n",
-    "    Γ       = Γ₁,      # Thermal inertia\n",
-    "    A_B     = 0.059,  # Bond albedo\n",
-    "    A_TH    = 0.0,    # Albedo in thermal infrared\n",
-    "    ε       = 0.9,    # Emissivity\n",
-    "    z_max   = 0.6,    # Maximum depth to solve the 1-D heat conduction (Lower boundary)\n",
-    "    Nz      = 61,     # Number of depth grid points to solve the 1-D heat conduction equation\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f1f3005b",
-   "metadata": {},
-   "source": [
-    "Thermal properties of Dimorphos"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2200ebd7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "thermo_params2 = AsteroidThermoPhysicalModels.thermoparams(\n",
-    "    P       = P₂,\n",
-    "    l       = l₂,\n",
-    "    Γ       = Γ₂,\n",
-    "    A_B     = 0.059,\n",
-    "    A_TH    = 0.0,\n",
-    "    ε       = 0.9,\n",
-    "    z_max   = 0.6,\n",
-    "    Nz      = 61,\n",
-    ")"
+    "println(\"Thermal skin depth of Didymos   : $l₁ [m]\")\n",
+    "println(\"Thermal skin depth of Dimorphos : $l₂ [m]\")\n",
+    "println(\"Thermal inertia                 : $Γ  [tiu]\")\n",
+    "println(\"Thermal diffusivity             : $α  [m²/s]\")"
    ]
   },
   {
@@ -331,25 +332,25 @@
    "outputs": [],
    "source": [
     "## TPM for Didymos\n",
-    "stpm1 = AsteroidThermoPhysicalModels.SingleTPM(shape1, thermo_params1;\n",
+    "stpm1 = AsteroidThermoPhysicalModels.SingleAsteroidTPM(shape1, thermo_params1;\n",
     "    SELF_SHADOWING = true,  # Enable self-shadowing, i.e., shadowing by local topography\n",
     "    SELF_HEATING   = true,  # Enable self-heating, i.e., energy exchange between interfacing facets\n",
-    "    SOLVER         = AsteroidThermoPhysicalModels.ForwardEulerSolver(thermo_params1),  # Solver for the 1-D heat conduction equation\n",
-    "    BC_UPPER       = AsteroidThermoPhysicalModels.RadiationBoundaryCondition(),        # Upper boundary condition (surface layer)\n",
-    "    BC_LOWER       = AsteroidThermoPhysicalModels.InsulationBoundaryCondition(),       # Lower boundary condition (bottom layer)\n",
+    "    SOLVER         = AsteroidThermoPhysicalModels.CrankNicolsonSolver(thermo_params1),  # Solver for the 1-D heat conduction equation\n",
+    "    BC_UPPER       = AsteroidThermoPhysicalModels.RadiationBoundaryCondition(),         # Upper boundary condition (surface layer)\n",
+    "    BC_LOWER       = AsteroidThermoPhysicalModels.InsulationBoundaryCondition(),        # Lower boundary condition (bottom layer)\n",
     ")\n",
     "\n",
     "## TPM for Dimorphos\n",
-    "stpm2 = AsteroidThermoPhysicalModels.SingleTPM(shape2, thermo_params2;\n",
+    "stpm2 = AsteroidThermoPhysicalModels.SingleAsteroidTPM(shape2, thermo_params2;\n",
     "    SELF_SHADOWING = true,\n",
     "    SELF_HEATING   = true,\n",
-    "    SOLVER         = AsteroidThermoPhysicalModels.ForwardEulerSolver(thermo_params2),\n",
+    "    SOLVER         = AsteroidThermoPhysicalModels.CrankNicolsonSolver(thermo_params2),\n",
     "    BC_UPPER       = AsteroidThermoPhysicalModels.RadiationBoundaryCondition(),\n",
     "    BC_LOWER       = AsteroidThermoPhysicalModels.InsulationBoundaryCondition(),\n",
     ")\n",
     "\n",
     "## Combine them to create a binary TPM\n",
-    "btpm = AsteroidThermoPhysicalModels.BinaryTPM(stpm1, stpm2;\n",
+    "btpm = AsteroidThermoPhysicalModels.BinaryAsteroidTPM(stpm1, stpm2;\n",
     "    MUTUAL_SHADOWING = true,   # Enable mutual shadowing, i.e., shadowing by the binary pair (eclipse)\n",
     "    MUTUAL_HEATING   = false,  # Enable mutual heating, i.e., energy exchange between the binary pair, taking much time for computation\n",
     ");"
@@ -420,10 +421,11 @@
    "id": "9d5b8df9",
    "metadata": {},
    "source": [
-    "Plot the energy conservation ratio `E_cons` to check computational convergence.\n",
+    "To check the convergence of a calculation, you can examine the ratio of the energy entering the asteroid to the energy leaving it.\n",
+    "This package records the out-going energy (`result.pri.E_out` and `result.sec.E_out`, [W]) and the in-coming energy (`result.pri.E_in` and `result.sec.E_out`, [W]) at each time step.\n",
+    "If there are no changes in solar distance or topographic effects, it converges to 1, averaged over the rotation period.\n",
     "\n",
-    "`E_cons` is defined as the ratio of the output energy to the input energy from the entire surface of the asteroid over one rotation.\n",
-    "As the thermal calculation converges, `E_cons` approaches 1."
+    "When a satellite enters the shadow of its primary body, the energy output/input ratio diverges."
    ]
   },
   {
@@ -436,14 +438,18 @@
     "fig = Figure()\n",
     "ax = Axis(fig[1, 1],\n",
     "    xlabel = \"Time [h]\",\n",
-    "    ylabel = \"E_cons [-]\",\n",
+    "    ylabel = \"E_out / E_in [-]\",\n",
+    "    limits = (nothing, (0.6, 1.1)),\n",
     ")\n",
     "\n",
     "xs = @. (ephem.time - ephem.time[begin]) / 3600  # Time since the beginning of TPM in unit of hour\n",
     "\n",
+    "ys1 = @. result.pri.E_out / result.pri.E_in      # Ratio of outgoing to incoming energy for Didymos\n",
+    "ys2 = @. result.sec.E_out / result.sec.E_in      # Ratio of outgoing to incoming energy for Dimorphos\n",
+    "\n",
     "hlines!(ax, [1], color=:black, linestyle=:dash)\n",
-    "scatterlines!(ax, xs, result.pri.E_cons, marker=:circle, markercolor=:blue,   label=\"Didymos\")\n",
-    "scatterlines!(ax, xs, result.sec.E_cons, marker=:circle, markercolor=:orange, label=\"Dimorphos\")\n",
+    "scatterlines!(ax, xs, ys1, marker=:circle, markercolor=:blue,   label=\"Didymos\")\n",
+    "scatterlines!(ax, xs, ys2, marker=:circle, markercolor=:orange, label=\"Dimorphos\")\n",
     "\n",
     "axislegend(ax, position=:rb)\n",
     "\n",
@@ -457,7 +463,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_shape(shape1; colorbar_title=\"Radius [m]\")  # Plot Didymos shape"
+    "# Plot Didymos shape with colorbar showing radius (default)\n",
+    "plot_shape(shape1; colorbar_title=\"Radius [m]\")"
    ]
   },
   {
@@ -467,7 +474,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_shape(shape2; colorbar_title=\"Radius [m]\")  # Plot Dimorphos shape"
+    "# Plot Dimorphos shape with colorbar showing radius (default)\n",
+    "plot_shape(shape2; colorbar_title=\"Radius [m]\")"
    ]
   },
   {
@@ -477,6 +485,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Plot Didymos shape with colorbar showing surface temperature during eclipse\n",
     "plot_shape(shape1;\n",
     "    title          = \"Temperature map at Didymos eclipse.\",\n",
     "    colorbar_title = \"Temperature [K]\",\n",
@@ -492,6 +501,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Plot Dimorphos shape with colorbar showing surface temperature during eclipse\n",
     "plot_shape(shape2;\n",
     "    title          = \"Temperature map at Dimorphos eclipse.\",\n",
     "    colorbar_title = \"Temperature [K]\",\n",
@@ -507,27 +517,19 @@
    "metadata": {},
    "outputs": [],
    "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "50e508c0",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.10.2",
+   "display_name": "Julia 1.11.5",
    "language": "julia",
-   "name": "julia-1.10"
+   "name": "julia-1.11"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.10.2"
+   "version": "1.11.5"
   }
  },
  "nbformat": 4,

--- a/TPM_Ryugu/README.md
+++ b/TPM_Ryugu/README.md
@@ -15,5 +15,5 @@ julia --project=.
  _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
 |__/                   |
 
-(Ryugu) pkg> add https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl#v0.0.6
+(Ryugu) pkg> add https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl#v0.0.7
 ```

--- a/TPM_Ryugu/TPM_Ryugu.ipynb
+++ b/TPM_Ryugu/TPM_Ryugu.ipynb
@@ -32,13 +32,13 @@
    "outputs": [],
    "source": [
     "# using Pkg\n",
-    "# Pkg.add(\"SPICE\")\n",
-    "# Pkg.add(\"Downloads\")\n",
-    "# Pkg.add(\"StaticArrays\")\n",
-    "# Pkg.add(\"Rotations\")\n",
     "# Pkg.add(\"CairoMakie\")\n",
+    "# Pkg.add(\"Downloads\")\n",
+    "# Pkg.add(\"Rotations\")\n",
+    "# Pkg.add(\"SPICE\")\n",
+    "# Pkg.add(\"StaticArrays\")\n",
     "\n",
-    "# Pkg.add(url=\"https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl\")"
+    "# Pkg.add(url=\"https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl#v0.0.7\")"
    ]
   },
   {
@@ -238,31 +238,35 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "k  = 0.1     # Thermal conductivity\n",
-    "ρ  = 1270.0  # Material density\n",
-    "Cₚ = 600.0   # Heat capacity at constant pressure\n",
-    "    \n",
-    "l = AsteroidThermoPhysicalModels.thermal_skin_depth(P, k, ρ, Cₚ)  # Thermal skin depth\n",
-    "Γ = AsteroidThermoPhysicalModels.thermal_inertia(k, ρ, Cₚ)        # Thermal inertia"
+    "k  = 0.1     # Thermal conductivity [W/m/K]\n",
+    "ρ  = 1270.0  # Density [kg/m³]\n",
+    "Cₚ = 600.0   # # Heat capacity at constant pressure [J/kg/K]\n",
+    "\n",
+    "R_vis = 0.059  # Reflectance in visible light [-]\n",
+    "R_ir  = 0.0    # Reflectance in thermal infrared [-]\n",
+    "ε     = 0.9    # Emissivity [-]\n",
+    "\n",
+    "z_max = 0.5                 # Depth of the lower boundary of a heat conduction equation [m]\n",
+    "n_depth = 101               # Number of depth steps\n",
+    "Δz = z_max / (n_depth - 1)  # Depth step width [m]\n",
+    "\n",
+    "thermo_params = AsteroidThermoPhysicalModels.ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth);"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1d50a811",
+   "id": "9125b1f2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "thermo_params = AsteroidThermoPhysicalModels.thermoparams(\n",
-    "    P       = P,     # Rotation period\n",
-    "    l       = l,     # Thermal skin depth\n",
-    "    Γ       = Γ,     # Thermal inertia\n",
-    "    A_B     = 0.04,  # Bond albedo\n",
-    "    A_TH    = 0.0,   # Albedo in thermal infrared\n",
-    "    ε       = 1.0,   # Emissivity\n",
-    "    z_max   = 0.6,   # Maximum depth to solve the 1-D heat conduction (Lower boundary)\n",
-    "    Nz      = 61,    # Number of depth grid points to solve the 1-D heat conduction equation\n",
-    ")"
+    "l = AsteroidThermoPhysicalModels.thermal_skin_depth(P, k, ρ, Cₚ)  # Thermal skin depth [m]\n",
+    "Γ = AsteroidThermoPhysicalModels.thermal_inertia(k, ρ, Cₚ)        # Thermal inertia [kg^(1/2) m^(1/2) s^(-1)]\n",
+    "α = AsteroidThermoPhysicalModels.thermal_diffusivity(k, ρ, Cₚ)    # Thermal diffusivity [m²/s]\n",
+    "\n",
+    "println(\"Thermal skin depth  : $l  [m]\")\n",
+    "println(\"Thermal inertia     : $Γ  [tiu]\")\n",
+    "println(\"Thermal diffusivity : $α  [m²/s]\")"
    ]
   },
   {
@@ -280,10 +284,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stpm = AsteroidThermoPhysicalModels.SingleTPM(shape, thermo_params;\n",
+    "stpm = AsteroidThermoPhysicalModels.SingleAsteroidTPM(shape, thermo_params;\n",
     "    SELF_SHADOWING = true,  # Enable self-shadowing, i.e., shadowing by local topography\n",
     "    SELF_HEATING   = true,  # Enable self-heating, i.e., energy exchange between interfacing facets\n",
-    "    SOLVER         = AsteroidThermoPhysicalModels.ForwardEulerSolver(thermo_params),  # Solver for the 1-D heat conduction equation\n",
+    "    SOLVER         = AsteroidThermoPhysicalModels.CrankNicolsonSolver(thermo_params), # Solver for the 1-D heat conduction equation\n",
     "    BC_UPPER       = AsteroidThermoPhysicalModels.RadiationBoundaryCondition(),       # Upper boundary condition (surface layer)\n",
     "    BC_LOWER       = AsteroidThermoPhysicalModels.InsulationBoundaryCondition(),      # Lower boundary condition (bottom layer)\n",
     ");"
@@ -353,10 +357,9 @@
    "id": "f872017f",
    "metadata": {},
    "source": [
-    "Plot the energy conservation ratio `E_cons` to check computational convergence.\n",
-    "\n",
-    "`E_cons` is defined as the ratio of the output energy to the input energy from the entire surface of the asteroid over one rotation.\n",
-    "As the thermal calculation converges, `E_cons` approaches 1."
+    "To check the convergence of a calculation, you can examine the ratio of the energy entering the asteroid to the energy leaving it.\n",
+    "This package records the out-going energy (`result.E_out`, [W]) and the in-coming energy (`result.E_in`, [W]) at each time step.\n",
+    "If there are no changes in solar distance or topographic effects, it converges to 1, averaged over the rotation period."
    ]
   },
   {
@@ -369,15 +372,24 @@
     "fig = Figure()\n",
     "ax = Axis(fig[1, 1],\n",
     "    xlabel = \"Time [h]\",\n",
-    "    ylabel = \"E_cons [-]\",\n",
+    "    ylabel = \"E_out / E_in [-]\",\n",
     ")\n",
     "\n",
     "xs = @. (ephem.time - ephem.time[begin]) / 3600  # Time since the beginning of TPM in unit of hour\n",
+    "ys = @. result.E_out / result.E_in               # Ratio of outgoing to incoming energy\n",
     "\n",
     "hlines!(ax, [1], color=:black, linestyle=:dash)\n",
-    "scatterlines!(ax, xs, result.E_cons, markercolor=:blue, marker=:circle)\n",
+    "scatterlines!(ax, xs, ys, markercolor=:blue, marker=:circle)\n",
     "\n",
     "display(fig)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "838f10ab",
+   "metadata": {},
+   "source": [
+    "3D quick-look function"
    ]
   },
   {
@@ -387,6 +399,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Plot the shape of the asteroid with colorbar showing radius (default)\n",
     "plot_shape(shape; colorbar_title=\"Radius [m]\")"
    ]
   },
@@ -397,6 +410,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Plot the shape of the asteroid with colorbar showing surface temperature at the final time step\n",
     "plot_shape(shape;\n",
     "    title          = \"Temperature map at the final time step.\",\n",
     "    colorbar_title = \"Temperature [K]\",\n",
@@ -404,14 +418,6 @@
     "    colorscale     = :thermal,\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2973d99f",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -424,15 +430,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.10.2",
+   "display_name": "Julia 1.11.5",
    "language": "julia",
-   "name": "julia-1.10"
+   "name": "julia-1.11"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.10.2"
+   "version": "1.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Summary
- Update sample code to be compatible with AsteroidThermoPhysicalModels.jl v0.0.7
- Address breaking changes introduced in v0.0.7

## Changes
- **Type naming updates**:
    - `SingleTPM` → `SingleAsteroidTPM`
    - `BinaryTPM` → `BinaryAsteroidTPM`
    - `thermoparams` → `ThermoParams`

- **Parameter updates**:
    - Replace albedo parameters (`A_B`, `A_TH`) with reflectance parameters (`R_vis`, `R_ir`)
    - `A_B = 0.059` → `R_vis = 0.059`
    - `A_TH = 0.0` → `R_ir = 0.0`

- **Updated examples**:
    - TPM_Didymos: Updated for v0.0.7
    - TPM_Ryugu: Updated for v0.0.7
    - TPM_Kanamaru2021: Remains on v0.0.4 as noted in README

- **Documentation**:
    - Update main README to indicate v0.0.7 compatibility
    - Update installation instructions in example READMEs