### PR TITLE
Update examples for `AsteroidThermoPhysicalModels.jl` v0.2.1 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ This repository contains example notebooks demonstrating the use of [AsteroidThe
 
 ## Compatibility
 
-These examples are compatible with **AsteroidThermoPhysicalModels.jl v0.0.7**.
+These examples are compatible with **AsteroidThermoPhysicalModels.jl v0.2.1**.
 
 For examples compatible with other versions:
 - v0.0.6: See the [v0.0.6-compatible branch](https://github.com/Astroshaper/Astroshaper-examples/tree/v0.0.6-compatible)
 
 ## Installation
 
-1. Install Julia (1.6 or later recommended)
+1. Install Julia (1.10 or later recommended)
 2. Clone this repository:
    ```bash
    git clone https://github.com/Astroshaper/Astroshaper-examples.git
@@ -67,13 +67,13 @@ To run an example:
 
 ## Requirements
 
-- Julia 1.6 or later
+- Julia 1.10 or later
 - Jupyter (via IJulia.jl)
 - Internet connection for downloading shape models and ephemeris data
 
 ## License
 
-These examples are provided under the same license as AsteroidThermoPhysicalModels.jl.
+These examples are provided under the same license as [AsteroidThermoPhysicalModels.jl](https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl).
 
 ## Contributing
 

--- a/TPM_Didymos/Project.toml
+++ b/TPM_Didymos/Project.toml
@@ -1,12 +1,11 @@
 [deps]
+AsteroidShapeModels = "a7943d8e-5d65-4248-ae23-0082f5115a05"
 AsteroidThermoPhysicalModels = "ab46f4a3-3c83-4d86-98d6-41a8b1a2e76e"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
-Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 SPICE = "5bab7191-041a-5c2e-a744-024b9c3a5062"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-AsteroidThermoPhysicalModels = "0.0.6"
+AsteroidThermoPhysicalModels = "0.2.1"

--- a/TPM_Didymos/README.md
+++ b/TPM_Didymos/README.md
@@ -11,9 +11,9 @@ julia --project=.
   (_)     | (_) (_)    |
    _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
   | | | | | | |/ _` |  |
-  | | |_| | | | (_| |  |  Version 1.8.4 (2022-12-23)
+  | | |_| | | | (_| |  |  Version 1.12.6 (2026-04-09)
  _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
 |__/                   |
 
-(TPM_Didymos) pkg> add https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl#v0.0.7
+(TPM_Didymos) pkg> add AsteroidThermoPhysicalModels@0.2.1
 ```

--- a/TPM_Didymos/TPM_Didymos.ipynb
+++ b/TPM_Didymos/TPM_Didymos.ipynb
@@ -10,6 +10,36 @@
   },
   {
    "cell_type": "markdown",
+   "id": "916bd9cd",
+   "metadata": {},
+   "source": [
+    "Compatible with [`AsteroidThermoPhysicalModels.jl`](https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl) v0.2.1."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0991cbe4",
+   "metadata": {},
+   "source": [
+    "**Inputs**\n",
+    "- SPICE kernels: rotation states and relative positions of Didymos/Dimorphos and the Sun over time (ephemerides)\n",
+    "- Shape models (OBJ files): polyhedral surface geometry of the primary and secondary\n",
+    "\n",
+    "**Workflow**\n",
+    "1. Build a `SingleAsteroidThermoPhysicalProblem` for each body (shape, thermal properties, boundary conditions)\n",
+    "2. Combine them into a `BinaryAsteroidThermoPhysicalProblem` (mutual shadowing/heating)\n",
+    "3. Build a `BinaryAsteroidOutputSpec` (what to save, and when, for each body)\n",
+    "4. `solve(problem, algorithm; ephem, output, initial_temperature_primary, initial_temperature_secondary)` → `BinaryAsteroidThermoPhysicalSolution`\n",
+    "5. `export_solution` → CSV files\n",
+    "\n",
+    "**Outputs**\n",
+    "- Surface temperature evolution for each body (`solution.primary.surface_temperature`, `solution.secondary.surface_temperature`)\n",
+    "- Subsurface temperature evolution for each body\n",
+    "- Whole-surface energy diagnostics for each body (`absorbed_power`, `emitted_power`)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "9ecb0b76",
    "metadata": {},
    "source": [
@@ -32,13 +62,12 @@
    "outputs": [],
    "source": [
     "# using Pkg\n",
-    "# Pkg.add(\"SPICE\")\n",
-    "# Pkg.add(\"Downloads\")\n",
-    "# Pkg.add(\"StaticArrays\")\n",
-    "# Pkg.add(\"Rotations\")\n",
+    "# Pkg.add(\"AsteroidShapeModels\")\n",
+    "# Pkg.add(\"AsteroidThermoPhysicalModels\")\n",
     "# Pkg.add(\"CairoMakie\")\n",
-    "\n",
-    "# Pkg.add(url=\"https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl#v0.0.7\")"
+    "# Pkg.add(\"Downloads\")\n",
+    "# Pkg.add(\"PlotlyJS\")\n",
+    "# Pkg.add(\"SPICE\")"
    ]
   },
   {
@@ -48,13 +77,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import AsteroidThermoPhysicalModels\n",
-    "import SPICE\n",
-    "\n",
-    "using Downloads\n",
-    "using StaticArrays\n",
-    "using Rotations\n",
+    "using AsteroidThermoPhysicalModels\n",
+    "using AsteroidShapeModels\n",
     "using CairoMakie\n",
+    "using Downloads\n",
+    "\n",
+    "import SPICE\n",
     "\n",
     "include(\"../plot_shape.jl\");"
    ]
@@ -94,7 +122,7 @@
     "\n",
     "##= Download SPICE kernels =##\n",
     "for path_kernel in paths_kernel\n",
-    "    url_kernel = \"https://s2e2.cosmos.esa.int/bitbucket/projects/SPICE_KERNELS/repos/hera/raw/kernels/$(path_kernel)?at=refs%2Ftags%2Fv161_20230929_001\"\n",
+    "    url_kernel = \"https://spiftp.esac.esa.int/data/SPICE/HERA/kernels/$(path_kernel)\"\n",
     "    filepath = joinpath(\"kernel\", path_kernel)\n",
     "    mkpath(dirname(filepath))\n",
     "    isfile(filepath) || Downloads.download(url_kernel, filepath)\n",
@@ -102,10 +130,10 @@
     "\n",
     "##= Download shape models =##\n",
     "for path_shape in paths_shape\n",
-    "    url_kernel = \"https://s2e2.cosmos.esa.int/bitbucket/projects/SPICE_KERNELS/repos/hera/raw/kernels/dsk/$(path_shape)?at=refs%2Ftags%2Fv161_20230929_001\"\n",
+    "    url_shape = \"https://spiftp.esac.esa.int/data/SPICE/HERA/kernels/dsk/$(path_shape)\"\n",
     "    filepath = joinpath(\"shape\", path_shape)\n",
     "    mkpath(dirname(filepath))\n",
-    "    isfile(filepath) || Downloads.download(url_kernel, filepath)\n",
+    "    isfile(filepath) || Downloads.download(url_shape, filepath)\n",
     "end"
    ]
   },
@@ -163,25 +191,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\"\"\"\n",
-    "Ephemerides data for input into a binary TPM,\n",
-    "including position vectors and rotation matrices depending on the time steps.\n",
+    "r_sun                  = [SPICE.spkpos(\"SUN\"      , et, \"DIDYMOS_FIXED\", \"None\", \"DIDYMOS\")[1] for et in et_range]  # Sun's position in DIDYMOS_FIXED [km]\n",
+    "r_secondary            = [SPICE.spkpos(\"DIMORPHOS\", et, \"DIDYMOS_FIXED\", \"None\", \"DIDYMOS\")[1] for et in et_range]  # Dimorphos position in DIDYMOS_FIXED [km]\n",
+    "R_primary_to_secondary = [SPICE.pxform(\"DIDYMOS_FIXED\", \"DIMORPHOS_FIXED\", et) for et in et_range]\n",
     "\n",
-    "- `time` : Ephemeris times\n",
-    "- `sun1` : Sun's position in the primary's frame (DIDYMOS_FIXED)\n",
-    "- `sun2` : Sun's position in the secondary's frame (DIMORPHOS_FIXED)\n",
-    "- `sec`  : Secondary's position in the primary's frame (DIDYMOS_FIXED)\n",
-    "- `P2S`  : Rotation matrix from primary to secondary frames\n",
-    "- `S2P`  : Rotation matrix from secondary to primary frames\n",
-    "\"\"\"\n",
-    "ephem = (\n",
-    "    time = collect(et_range),\n",
-    "    sun1 = [SVector{3}(SPICE.spkpos(\"SUN\"      , et, \"DIDYMOS_FIXED\"  , \"None\", \"DIDYMOS\"  )[1]) * 1000 for et in et_range],\n",
-    "    sun2 = [SVector{3}(SPICE.spkpos(\"SUN\"      , et, \"DIMORPHOS_FIXED\", \"None\", \"DIMORPHOS\")[1]) * 1000 for et in et_range],\n",
-    "    sec  = [SVector{3}(SPICE.spkpos(\"DIMORPHOS\", et, \"DIDYMOS_FIXED\"  , \"None\", \"DIDYMOS\"  )[1]) * 1000 for et in et_range],\n",
-    "    P2S  = [RotMatrix{3}(SPICE.pxform(\"DIDYMOS_FIXED\"  , \"DIMORPHOS_FIXED\", et)) for et in et_range],\n",
-    "    S2P  = [RotMatrix{3}(SPICE.pxform(\"DIMORPHOS_FIXED\", \"DIDYMOS_FIXED\"  , et)) for et in et_range],\n",
-    ");"
+    "r_sun       .*= 1000  # Convert [km] to [m]\n",
+    "r_secondary .*= 1000  # Convert [km] to [m]\n",
+    "\n",
+    "ephem = BinaryAsteroidEphemerides(et_range, r_sun, r_secondary, R_primary_to_secondary);"
    ]
   },
   {
@@ -221,8 +238,8 @@
     "path_shape1_obj = joinpath(\"shape\", \"g_50677mm_rad_obj_didy_0000n00000_v001.obj\")\n",
     "path_shape2_obj = joinpath(\"shape\", \"g_08438mm_lgt_obj_dimo_0000n00000_v002.obj\")\n",
     "\n",
-    "shape1 = AsteroidThermoPhysicalModels.load_shape_obj(path_shape1_obj; scale=1000, find_visible_facets=true)\n",
-    "shape2 = AsteroidThermoPhysicalModels.load_shape_obj(path_shape2_obj; scale=1000, find_visible_facets=true)\n",
+    "shape1 = load_shape_obj(path_shape1_obj; scale=1000, with_face_visibility=true, with_bvh=true)\n",
+    "shape2 = load_shape_obj(path_shape2_obj; scale=1000, with_face_visibility=true, with_bvh=true)\n",
     "\n",
     "println(shape1)  # Didymos shape model\n",
     "println(shape2)  # Dimorphos shape model"
@@ -233,7 +250,7 @@
    "id": "db9ab824",
    "metadata": {},
    "source": [
-    "# TPM setup and execution"
+    "# TPM Setup"
    ]
   },
   {
@@ -263,7 +280,7 @@
     "n_depth = 101               # Number of depth steps\n",
     "Δz = z_max / (n_depth - 1)  # Depth step width [m]\n",
     "\n",
-    "thermo_params1 = AsteroidThermoPhysicalModels.ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth);"
+    "thermo_params1 = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth);"
    ]
   },
   {
@@ -295,7 +312,7 @@
     "n_depth = 101               # Number of depth steps\n",
     "Δz = z_max / (n_depth - 1)  # Depth step width [m]\n",
     "\n",
-    "thermo_params2 = AsteroidThermoPhysicalModels.ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth);"
+    "thermo_params2 = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth);"
    ]
   },
   {
@@ -321,7 +338,7 @@
    "id": "7fbf3a0e",
    "metadata": {},
    "source": [
-    "Create a model for the binary asteroid"
+    "Create problems for the binary asteroid"
    ]
   },
   {
@@ -331,39 +348,41 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## TPM for Didymos\n",
-    "stpm1 = AsteroidThermoPhysicalModels.SingleAsteroidTPM(shape1, thermo_params1;\n",
-    "    SELF_SHADOWING = true,  # Enable self-shadowing, i.e., shadowing by local topography\n",
-    "    SELF_HEATING   = true,  # Enable self-heating, i.e., energy exchange between interfacing facets\n",
-    "    SOLVER         = AsteroidThermoPhysicalModels.CrankNicolsonSolver(thermo_params1),  # Solver for the 1-D heat conduction equation\n",
-    "    BC_UPPER       = AsteroidThermoPhysicalModels.RadiationBoundaryCondition(),         # Upper boundary condition (surface layer)\n",
-    "    BC_LOWER       = AsteroidThermoPhysicalModels.InsulationBoundaryCondition(),        # Lower boundary condition (bottom layer)\n",
-    ")\n",
-    "\n",
-    "## TPM for Dimorphos\n",
-    "stpm2 = AsteroidThermoPhysicalModels.SingleAsteroidTPM(shape2, thermo_params2;\n",
-    "    SELF_SHADOWING = true,\n",
-    "    SELF_HEATING   = true,\n",
-    "    SOLVER         = AsteroidThermoPhysicalModels.CrankNicolsonSolver(thermo_params2),\n",
-    "    BC_UPPER       = AsteroidThermoPhysicalModels.RadiationBoundaryCondition(),\n",
-    "    BC_LOWER       = AsteroidThermoPhysicalModels.InsulationBoundaryCondition(),\n",
-    ")\n",
-    "\n",
-    "## Combine them to create a binary TPM\n",
-    "btpm = AsteroidThermoPhysicalModels.BinaryAsteroidTPM(stpm1, stpm2;\n",
-    "    MUTUAL_SHADOWING = true,   # Enable mutual shadowing, i.e., shadowing by the binary pair (eclipse)\n",
-    "    MUTUAL_HEATING   = false,  # Enable mutual heating, i.e., energy exchange between the binary pair, taking much time for computation\n",
+    "problem = BinaryAsteroidThermoPhysicalProblem(\n",
+    "    (shape1, shape2),\n",
+    "    (thermo_params1, thermo_params2);\n",
+    "    with_self_shadowing      = true,  # Enable self-shadowing, i.e., shadowing by local topography\n",
+    "    with_self_heating        = true,  # Enable self-heating, i.e., energy exchange between interfacing facets\n",
+    "    upper_boundary_condition = RadiationBoundaryCondition(),   # Upper boundary condition (surface layer)\n",
+    "    lower_boundary_condition = InsulationBoundaryCondition(),  # Lower boundary condition (bottom layer)\n",
+    "    with_mutual_shadowing    = true,   # Enable mutual shadowing, i.e., shadowing by the binary pair (eclipse)\n",
+    "    with_mutual_heating      = false,  # Enable mutual heating, i.e., energy exchange between the binary pair, taking much time for computation\n",
     ");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dbfc72f8",
+   "metadata": {},
+   "source": [
+    "Data output specification"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c292580",
+   "id": "bbd3c2e6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "AsteroidThermoPhysicalModels.init_temperature!(btpm, 240);  # Intial temperature [K]"
+    "output_times         = ephem.times[end-nsteps_in_cycle:end]  # Save temperature during the final rotation\n",
+    "subsurface_face_ids1 = [1, 2, 3, 4, 10]  # Face indices to save subsurface temperature of Didymos\n",
+    "subsurface_face_ids2 = [1, 2, 3, 4, 20]  # Face indices to save subsurface temperature of Dimorphos\n",
+    "\n",
+    "output = BinaryAsteroidOutputSpec(\n",
+    "    SingleAsteroidOutputSpec(output_times, subsurface_face_ids1),\n",
+    "    SingleAsteroidOutputSpec(output_times, subsurface_face_ids2),\n",
+    ");"
    ]
   },
   {
@@ -371,7 +390,7 @@
    "id": "0ccca087",
    "metadata": {},
    "source": [
-    "Run TPM"
+    "# TPM Execution and Export"
    ]
   },
   {
@@ -381,11 +400,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "times_to_save = ephem.time[end-nsteps_in_cycle:end]  # Save temperature during the final rotation\n",
-    "face_ID_pri = [1, 2, 3, 4, 10]  # Face indices to save subsurface temperature of Didymos\n",
-    "face_ID_sec = [1, 2, 3, 4, 20]  # Face indices to save subsurface temperature of Dimorphos\n",
-    "\n",
-    "result = AsteroidThermoPhysicalModels.run_TPM!(btpm, ephem, times_to_save, face_ID_pri, face_ID_sec; show_progress=false);"
+    "solution = solve(problem, CrankNicolson();\n",
+    "    ephem                         = ephem,\n",
+    "    output                        = output,\n",
+    "    initial_temperature_primary   = 240.0,  # Initial temperature of Didymos [K]\n",
+    "    initial_temperature_secondary = 240.0,  # Initial temperature of Dimorphos [K]\n",
+    "    show_progress                 = false,\n",
+    ");"
    ]
   },
   {
@@ -405,7 +426,7 @@
    "source": [
     "dirpath = \"./output\"\n",
     "mkpath(dirpath)\n",
-    "AsteroidThermoPhysicalModels.export_TPM_results(dirpath, result)"
+    "export_solution(dirpath, solution);"
    ]
   },
   {
@@ -422,7 +443,7 @@
    "metadata": {},
    "source": [
     "To check the convergence of a calculation, you can examine the ratio of the energy entering the asteroid to the energy leaving it.\n",
-    "This package records the out-going energy (`result.pri.E_out` and `result.sec.E_out`, [W]) and the in-coming energy (`result.pri.E_in` and `result.sec.E_out`, [W]) at each time step.\n",
+    "This package records the out-going energy (`solution.primary.emitted_power` and `solution.secondary.emitted_power`, [W]) and the in-coming energy (`solution.primary.absorbed_power` and `solution.secondary.absorbed_power`, [W]) at each time step.\n",
     "If there are no changes in solar distance or topographic effects, it converges to 1, averaged over the rotation period.\n",
     "\n",
     "When a satellite enters the shadow of its primary body, the energy output/input ratio diverges."
@@ -438,14 +459,14 @@
     "fig = Figure()\n",
     "ax = Axis(fig[1, 1],\n",
     "    xlabel = \"Time [h]\",\n",
-    "    ylabel = \"E_out / E_in [-]\",\n",
+    "    ylabel = \"emitted_power / absorbed_power [-]\",\n",
     "    limits = (nothing, (0.6, 1.1)),\n",
     ")\n",
     "\n",
-    "xs = @. (ephem.time - ephem.time[begin]) / 3600  # Time since the beginning of TPM in unit of hour\n",
+    "xs = @. (solution.primary.times - solution.primary.times[begin]) / 3600  # Time since the beginning of TPM in unit of hour\n",
     "\n",
-    "ys1 = @. result.pri.E_out / result.pri.E_in      # Ratio of outgoing to incoming energy for Didymos\n",
-    "ys2 = @. result.sec.E_out / result.sec.E_in      # Ratio of outgoing to incoming energy for Dimorphos\n",
+    "ys1 = @. solution.primary.emitted_power   / solution.primary.absorbed_power    # Ratio of outgoing to incoming energy for Didymos\n",
+    "ys2 = @. solution.secondary.emitted_power / solution.secondary.absorbed_power  # Ratio of outgoing to incoming energy for Dimorphos\n",
     "\n",
     "hlines!(ax, [1], color=:black, linestyle=:dash)\n",
     "scatterlines!(ax, xs, ys1, marker=:circle, markercolor=:blue,   label=\"Didymos\")\n",
@@ -489,7 +510,7 @@
     "plot_shape(shape1;\n",
     "    title          = \"Temperature map at Didymos eclipse.\",\n",
     "    colorbar_title = \"Temperature [K]\",\n",
-    "    intensity      = result.pri.surface_temperature[:, end-126],\n",
+    "    intensity      = solution.primary.surface_temperature[:, end-126],\n",
     "    colorscale     = :thermal,\n",
     ")"
    ]
@@ -505,7 +526,7 @@
     "plot_shape(shape2;\n",
     "    title          = \"Temperature map at Dimorphos eclipse.\",\n",
     "    colorbar_title = \"Temperature [K]\",\n",
-    "    intensity      = result.sec.surface_temperature[:, 70],\n",
+    "    intensity      = solution.secondary.surface_temperature[:, 70],\n",
     "    colorscale     = :thermal,\n",
     ")"
    ]
@@ -521,15 +542,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.11.5",
+   "display_name": "Julia 1.12.6",
    "language": "julia",
-   "name": "julia-1.11"
+   "name": "julia-1.12"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.11.5"
+   "version": "1.12.6"
   }
  },
  "nbformat": 4,

--- a/TPM_Ryugu/Project.toml
+++ b/TPM_Ryugu/Project.toml
@@ -1,12 +1,11 @@
 [deps]
+AsteroidShapeModels = "a7943d8e-5d65-4248-ae23-0082f5115a05"
 AsteroidThermoPhysicalModels = "ab46f4a3-3c83-4d86-98d6-41a8b1a2e76e"
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
-Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 SPICE = "5bab7191-041a-5c2e-a744-024b9c3a5062"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-AsteroidThermoPhysicalModels = "0.0.6"
+AsteroidThermoPhysicalModels = "0.2.1"

--- a/TPM_Ryugu/README.md
+++ b/TPM_Ryugu/README.md
@@ -11,9 +11,9 @@ julia --project=.
   (_)     | (_) (_)    |
    _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
   | | | | | | |/ _` |  |
-  | | |_| | | | (_| |  |  Version 1.8.4 (2022-12-23)
+  | | |_| | | | (_| |  |  Version 1.12.6 (2026-04-09)
  _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
 |__/                   |
 
-(Ryugu) pkg> add https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl#v0.0.7
+(Ryugu) pkg> add AsteroidThermoPhysicalModels@0.2.1
 ```

--- a/TPM_Ryugu/TPM_Ryugu.ipynb
+++ b/TPM_Ryugu/TPM_Ryugu.ipynb
@@ -10,6 +10,35 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3e017790",
+   "metadata": {},
+   "source": [
+    "Compatible with [`AsteroidThermoPhysicalModels.jl`](https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl) v0.2.1."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a271ca53",
+   "metadata": {},
+   "source": [
+    "**Inputs**\n",
+    "- SPICE kernels: rotation state and Sun's position over time (ephemerides)\n",
+    "- Shape model (OBJ file): polyhedral surface geometry\n",
+    "\n",
+    "**Workflow**\n",
+    "1. Build a `SingleAsteroidThermoPhysicalProblem` (shape, thermal properties, boundary conditions)\n",
+    "2. Build a `SingleAsteroidOutputSpec` (what to save, and when)\n",
+    "3. `solve(problem, algorithm; ephem, output, initial_temperature)` → `SingleAsteroidThermoPhysicalSolution`\n",
+    "4. `export_solution` → CSV files\n",
+    "\n",
+    "**Outputs**\n",
+    "- Surface temperature evolution (`solution.surface_temperature`)\n",
+    "- Subsurface temperature evolution (`solution.subsurface_temperature`)\n",
+    "- Whole-surface energy diagnostics (`solution.absorbed_power`, `solution.emitted_power`)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "9ecb0b76",
    "metadata": {},
    "source": [
@@ -32,13 +61,12 @@
    "outputs": [],
    "source": [
     "# using Pkg\n",
+    "# Pkg.add(\"AsteroidShapeModels\")\n",
+    "# Pkg.add(\"AsteroidThermoPhysicalModels\")\n",
     "# Pkg.add(\"CairoMakie\")\n",
     "# Pkg.add(\"Downloads\")\n",
-    "# Pkg.add(\"Rotations\")\n",
-    "# Pkg.add(\"SPICE\")\n",
-    "# Pkg.add(\"StaticArrays\")\n",
-    "\n",
-    "# Pkg.add(url=\"https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl#v0.0.7\")"
+    "# Pkg.add(\"PlotlyJS\")\n",
+    "# Pkg.add(\"SPICE\")"
    ]
   },
   {
@@ -48,13 +76,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import AsteroidThermoPhysicalModels\n",
-    "import SPICE\n",
-    "\n",
-    "using Downloads\n",
-    "using StaticArrays\n",
-    "using Rotations\n",
+    "using AsteroidThermoPhysicalModels\n",
+    "using AsteroidShapeModels\n",
     "using CairoMakie\n",
+    "using Downloads\n",
+    "\n",
+    "import SPICE\n",
     "\n",
     "include(\"../plot_shape.jl\");"
    ]
@@ -88,7 +115,7 @@
     "]\n",
     "\n",
     "for path_kernel in paths_kernel\n",
-    "    url_kernel = \"https://data.darts.isas.jaxa.jp/pub/hayabusa2/spice_bundle/spice_kernels/$(path_kernel)\"\n",
+    "    url_kernel = \"https://data.darts.isas.jaxa.jp/pub/hayabusa2/old/2020/spice_bundle/spice_kernels/$(path_kernel)\"\n",
     "    filepath = joinpath(\"kernel\", path_kernel)\n",
     "    mkpath(dirname(filepath))\n",
     "    isfile(filepath) || Downloads.download(url_kernel, filepath)\n",
@@ -155,16 +182,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\"\"\"\n",
-    "Ephemerides data for input into TPM.\n",
+    "r_sun = [SPICE.spkpos(\"SUN\", et, \"RYUGU_FIXED\", \"None\", \"RYUGU\")[1] for et in et_range]  # Sun's position in RYUGU_FIXED [km]\n",
+    "r_sun .*= 1000  # Convert [km] to [m]\n",
     "\n",
-    "- `time` : Ephemeris times\n",
-    "- `sun`  : Sun's position in the RYUGU_FIXED frame\n",
-    "\"\"\"\n",
-    "ephem = (\n",
-    "    time = collect(et_range),\n",
-    "    sun  = [SVector{3}(SPICE.spkpos(\"SUN\", et, \"RYUGU_FIXED\", \"None\", \"RYUGU\")[1]) * 1000 for et in et_range],\n",
-    ");"
+    "ephem = SingleAsteroidEphemerides(et_range, r_sun);"
    ]
   },
   {
@@ -212,7 +233,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "shape = AsteroidThermoPhysicalModels.load_shape_obj(path_obj; scale=1000, find_visible_facets=true)"
+    "shape = load_shape_obj(path_obj; scale=1000, with_face_visibility=true, with_bvh=true)"
    ]
   },
   {
@@ -220,7 +241,7 @@
    "id": "db9ab824",
    "metadata": {},
    "source": [
-    "# TPM setup and execution"
+    "# TPM Setup"
    ]
   },
   {
@@ -250,7 +271,7 @@
     "n_depth = 101               # Number of depth steps\n",
     "Δz = z_max / (n_depth - 1)  # Depth step width [m]\n",
     "\n",
-    "thermo_params = AsteroidThermoPhysicalModels.ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth);"
+    "thermo_params = ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth);"
    ]
   },
   {
@@ -274,7 +295,7 @@
    "id": "88a0e044",
    "metadata": {},
    "source": [
-    "Create a model for the single asteroid"
+    "Create a problem for the single asteroid"
    ]
   },
   {
@@ -284,23 +305,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stpm = AsteroidThermoPhysicalModels.SingleAsteroidTPM(shape, thermo_params;\n",
-    "    SELF_SHADOWING = true,  # Enable self-shadowing, i.e., shadowing by local topography\n",
-    "    SELF_HEATING   = true,  # Enable self-heating, i.e., energy exchange between interfacing facets\n",
-    "    SOLVER         = AsteroidThermoPhysicalModels.CrankNicolsonSolver(thermo_params), # Solver for the 1-D heat conduction equation\n",
-    "    BC_UPPER       = AsteroidThermoPhysicalModels.RadiationBoundaryCondition(),       # Upper boundary condition (surface layer)\n",
-    "    BC_LOWER       = AsteroidThermoPhysicalModels.InsulationBoundaryCondition(),      # Lower boundary condition (bottom layer)\n",
+    "problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;\n",
+    "    with_self_shadowing      = true,  # Enable self-shadowing, i.e., shadowing by local topography\n",
+    "    with_self_heating        = true,  # Enable self-heating, i.e., energy exchange between interfacing facets\n",
+    "    upper_boundary_condition = RadiationBoundaryCondition(),   # Upper boundary condition (surface layer)\n",
+    "    lower_boundary_condition = InsulationBoundaryCondition(),  # Lower boundary condition (bottom layer)\n",
     ");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "207496c9",
+   "metadata": {},
+   "source": [
+    "Data ouput specification"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cb5612b1",
+   "id": "b63c37b4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "AsteroidThermoPhysicalModels.init_temperature!(stpm, 240);  # Intial temperature [K]"
+    "output_times        = ephem.times[end-nsteps_in_cycle:end]  # Save temperature during the final rotation\n",
+    "subsurface_face_ids = [1, 2, 3, 4, 10]  # Face indices to save subsurface temperature\n",
+    "\n",
+    "output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids);"
    ]
   },
   {
@@ -308,7 +339,7 @@
    "id": "45e0c00e",
    "metadata": {},
    "source": [
-    "Run TPM"
+    "# TPM Execution and Export"
    ]
   },
   {
@@ -318,10 +349,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "times_to_save = ephem.time[end-nsteps_in_cycle:end]  # Save temperature during the final rotation\n",
-    "face_ID = [1, 2, 3, 4, 10]  # Face indices to save subsurface temperature\n",
-    "\n",
-    "result = AsteroidThermoPhysicalModels.run_TPM!(stpm, ephem, times_to_save, face_ID; show_progress=false);"
+    "solution = solve(problem, CrankNicolson();\n",
+    "    ephem               = ephem,\n",
+    "    output              = output,\n",
+    "    initial_temperature = 240.0,  # Initial temperature [K]\n",
+    "    show_progress       = false,\n",
+    ");"
    ]
   },
   {
@@ -341,7 +374,7 @@
    "source": [
     "dirpath = \"./output\"\n",
     "mkpath(dirpath)\n",
-    "AsteroidThermoPhysicalModels.export_TPM_results(dirpath, result)"
+    "export_solution(dirpath, solution);"
    ]
   },
   {
@@ -358,7 +391,7 @@
    "metadata": {},
    "source": [
     "To check the convergence of a calculation, you can examine the ratio of the energy entering the asteroid to the energy leaving it.\n",
-    "This package records the out-going energy (`result.E_out`, [W]) and the in-coming energy (`result.E_in`, [W]) at each time step.\n",
+    "This package records the out-going energy (`solution.emitted_power`, [W]) and the in-coming energy (`solution.absorbed_power`, [W]) at each time step.\n",
     "If there are no changes in solar distance or topographic effects, it converges to 1, averaged over the rotation period."
    ]
   },
@@ -372,11 +405,11 @@
     "fig = Figure()\n",
     "ax = Axis(fig[1, 1],\n",
     "    xlabel = \"Time [h]\",\n",
-    "    ylabel = \"E_out / E_in [-]\",\n",
+    "    ylabel = \"emitted_power / absorbed_power [-]\",\n",
     ")\n",
     "\n",
-    "xs = @. (ephem.time - ephem.time[begin]) / 3600  # Time since the beginning of TPM in unit of hour\n",
-    "ys = @. result.E_out / result.E_in               # Ratio of outgoing to incoming energy\n",
+    "xs = @. (solution.times - solution.times[begin]) / 3600  # Time since the beginning of TPM in unit of hour\n",
+    "ys = @. solution.emitted_power / solution.absorbed_power  # Ratio of outgoing to incoming energy\n",
     "\n",
     "hlines!(ax, [1], color=:black, linestyle=:dash)\n",
     "scatterlines!(ax, xs, ys, markercolor=:blue, marker=:circle)\n",
@@ -414,7 +447,7 @@
     "plot_shape(shape;\n",
     "    title          = \"Temperature map at the final time step.\",\n",
     "    colorbar_title = \"Temperature [K]\",\n",
-    "    intensity      = result.surface_temperature[:, end],\n",
+    "    intensity      = solution.surface_temperature[:, end],\n",
     "    colorscale     = :thermal,\n",
     ")"
    ]
@@ -430,15 +463,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Julia 1.11.5",
+   "display_name": "Julia 1.12.6",
    "language": "julia",
-   "name": "julia-1.11"
+   "name": "julia-1.12"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.11.5"
+   "version": "1.12.6"
   }
  },
  "nbformat": 4,

--- a/plot_shape.jl
+++ b/plot_shape.jl
@@ -92,13 +92,13 @@ end
 
 
 function extract_edges(shape)
-    edges = Set{SVector{2, Int64}}()
+    edges = Set{Tuple{Int64, Int64}}()
 
     for face in shape.faces
         ## Add each side of face in order of decreasing node ID
-        push!(edges, [min(face[1], face[2]), max(face[1], face[2])])
-        push!(edges, [min(face[2], face[3]), max(face[2], face[3])])
-        push!(edges, [min(face[3], face[1]), max(face[3], face[1])])
+        push!(edges, (min(face[1], face[2]), max(face[1], face[2])))
+        push!(edges, (min(face[2], face[3]), max(face[2], face[3])))
+        push!(edges, (min(face[3], face[1]), max(face[3], face[1])))
     end
 
     return edges


### PR DESCRIPTION
## Summary
- Migrate `TPM_Ryugu` and `TPM_Didymos` notebooks to the AsteroidThermoPhysicalModels.jl v0.2.1 API: `SingleAsteroidThermoPhysicalProblem`, `solve(problem, CrankNicolson(); ...)`, `SingleAsteroidOutputSpec`, `export_solution`, and shape loading moved to `AsteroidShapeModels.jl` (`load_shape_obj` with `with_face_visibility`/`with_bvh`).
- Update `Project.toml` and `README.md` in both example directories (and the root `README.md`) to reflect v0.2.1 and Julia 1.10+.
- Fix `plot_shape.jl`, which implicitly relied on the notebooks' `using StaticArrays` for `SVector`; replaced with a plain `Tuple{Int64,Int64}` for edge deduplication so it no longer depends on a package the notebooks don't otherwise need.

## Test plan
- [x] Ran both notebooks end-to-end in their respective project environments and confirmed they execute without error
- [x] Verified `SingleAsteroidEphemerides`, `SingleAsteroidThermoPhysicalProblem`, `solve`/`CrankNicolson`, `SingleAsteroidOutputSpec`, `export_solution`, and `solution.emitted_power`/`absorbed_power` against the installed v0.2.1 package source
- [x] Confirmed notebook outputs/execution counts are cleared before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)