### PR TITLE
docs: add CHANGELOG.md and adopt date-based release tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+This file records when the example notebooks in this repository were updated to
+track a new version of the library they demonstrate.
+
+## Versioning convention
+
+- Each entry below corresponds to a git tag named after the date the change was
+  merged (`YYYY-MM-DD`), e.g. [`2026-07-08`](https://github.com/Astroshaper/Astroshaper-examples/tree/2026-07-08).
+- This repository is not a registered Julia package, so tags are not Semantic
+  Versioning — they are just checkpoints you can check out to see the examples
+  as they were for a specific past library version.
+- The authoritative source for "which library version does this example target
+  right now" is each example's own `Project.toml` `[compat]` entry, tracked in
+  git history for that path.
+
+## 2026-07-08
+
+### AsteroidThermoPhysicalModels.jl: v0.0.7 → v0.2.1
+
+- Migrated `TPM_Ryugu` and `TPM_Didymos` to the v0.2.1 Problem/Solver API
+  (`SingleAsteroidThermoPhysicalProblem`, `solve`/`CrankNicolson`,
+  `SingleAsteroidOutputSpec`, `export_solution`), and moved shape loading to
+  `AsteroidShapeModels.jl`.
+- Commit: [`23caad54`](https://github.com/Astroshaper/Astroshaper-examples/commit/23caad54a3335063d9c0b71bedf6e935331b5fbe) (PR [#18](https://github.com/Astroshaper/Astroshaper-examples/pull/18))
+- Tag: [`2026-07-08`](https://github.com/Astroshaper/Astroshaper-examples/tree/2026-07-08)
+- Previous state: tag [`v0.0.7-compatible`](https://github.com/Astroshaper/Astroshaper-examples/tree/v0.0.7-compatible)
+
+## 2025-06-06
+
+### AsteroidThermoPhysicalModels.jl: v0.0.6 → v0.0.7
+
+- Updated `TPM_Ryugu` and `TPM_Didymos` for the v0.0.7 API.
+- Commit: [`59b23959`](https://github.com/Astroshaper/Astroshaper-examples/commit/59b23959f6c73d9849f37711e49605cf09c51ad1) (PR [#17](https://github.com/Astroshaper/Astroshaper-examples/pull/17))
+- Tag: [`v0.0.7-compatible`](https://github.com/Astroshaper/Astroshaper-examples/tree/v0.0.7-compatible)
+- Previous state: tag [`v0.0.6-compatible`](https://github.com/Astroshaper/Astroshaper-examples/tree/v0.0.6-compatible)

--- a/README.md
+++ b/README.md
@@ -6,13 +6,6 @@ Example code for [Astroshaper](https://github.com/Astroshaper) packages.
 
 This repository contains example notebooks demonstrating the use of [AsteroidThermoPhysicalModels.jl](https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl) for thermophysical modeling of asteroids.
 
-## Compatibility
-
-These examples are compatible with **AsteroidThermoPhysicalModels.jl v0.2.1**.
-
-For examples compatible with other versions:
-- v0.0.6: See the [v0.0.6-compatible branch](https://github.com/Astroshaper/Astroshaper-examples/tree/v0.0.6-compatible)
-
 ## Installation
 
 1. Install Julia (1.10 or later recommended)
@@ -30,18 +23,20 @@ Thermophysical modeling (TPM) calculation for asteroid [Ryugu](https://en.wikipe
 - Single asteroid TPM
 - Temperature distribution analysis
 - Non-gravitational forces calculation
+- Compatible with: [AsteroidThermoPhysicalModels.jl](https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl) v0.2.1 (see [CHANGELOG.md](CHANGELOG.md) for older versions)
 
 ### TPM_Didymos
 TPM calculation for the binary asteroid system [Didymos](https://en.wikipedia.org/wiki/65803_Didymos).
 - Binary asteroid TPM
 - Mutual shadowing (eclipses)
 - Mutual heating between primary and secondary
+- Compatible with: [AsteroidThermoPhysicalModels.jl](https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl) v0.2.1 (see [CHANGELOG.md](CHANGELOG.md) for older versions)
 
 ### TPM_Kanamaru2021
 Example notebook for YORP simulation in [Kanamaru et al. (2021)](https://doi.org/10.1029/2021JE006863).
 - YORP effect calculation
 - Long-term rotational evolution
-- *Note: Currently compatible with v0.0.4 only*
+- Compatible with: [AsteroidThermoPhysicalModels.jl](https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl) v0.0.4 only (not yet migrated)
 
 ## Running the Examples
 


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` as the append-only record of when each example folder was updated to track a new library version, replacing the old convention of encoding the library version directly into the git tag name (which doesn't scale once the repo hosts examples for multiple independently-versioned libraries).
- Adopt `YYYY-MM-DD` tags (e.g. `2026-07-08`, already pushed) for these checkpoints instead of `vX.Y.Z-compatible` tags, since this repo isn't a registered package and has no downstream consumers relying on SemVer.
- Fold the old top-level `## Compatibility` README section into each example's own bullet list (`Compatible with: ...`), so compatibility info lives next to the example it describes rather than in a single repo-wide note that's easy to forget to update (the previous version had already gone stale, missing a link to the `v0.0.7-compatible` tag).
- Existing `v0.0.6-compatible` / `v0.0.7-compatible` tags are left as-is and referenced from `CHANGELOG.md` as legacy checkpoints.

## Test plan
- [x] Confirmed `2026-07-08` tag points at the already-merged v0.2.1 migration commit (`23caad54`, PR #18)
- [x] Reviewed rendered README/CHANGELOG links for correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)