### PR TITLE
docs: add AGENTS.md and switch tag naming to vYYYY-MM-DD

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# AGENTS.md
+
+Instructions for AI coding agents working in this repository.
+
+## What this repository is
+
+Example Jupyter notebooks demonstrating [Astroshaper](https://github.com/Astroshaper) packages
+(currently [AsteroidThermoPhysicalModels.jl](https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl);
+more packages are expected to get their own examples over time). Each top-level `TPM_*`
+directory is a self-contained Julia project (its own `Project.toml`) holding one notebook
+plus a `README.md`.
+
+## Repository layout
+
+- `TPM_Ryugu/`, `TPM_Didymos/` — actively maintained, kept up to date with the latest
+  AsteroidThermoPhysicalModels.jl API.
+- `TPM_Kanamaru2021/` — **frozen**. Intentionally left on AsteroidThermoPhysicalModels.jl
+  v0.0.4. Do not migrate this notebook to a newer API unless explicitly asked to — its code
+  has diverged too far from later versions to update casually.
+- `plot_shape.jl` (repo root) — shared PlotlyJS plotting helper, `include`d by the notebooks.
+  It has no `Project.toml` of its own, so whatever packages it uses (currently
+  `LinearAlgebra`, `PlotlyJS`) must be listed as deps in *every* example's `Project.toml`
+  that includes it. If you add an import to this file, add the dependency to each consuming
+  example's `Project.toml`, not just the one you happened to test with.
+
+## When migrating an example to a new library version
+
+1. Update the notebook's API calls, its `Project.toml` `[deps]`/`[compat]`, and its own
+   `README.md`.
+2. Update the root `README.md`'s `Compatible with: ...` line for that example, under
+   `## Available Examples`.
+3. Add an entry to the root `CHANGELOG.md` (date, library, old → new version, commit hash,
+   PR number). See that file's "Versioning convention" section for the full policy and why
+   tags are dated rather than versioned.
+4. After merging, tag the merge commit with the merge date as `vYYYY-MM-DD` — this is not
+   SemVer (this repo is not a registered package); the `v` is just a conventional prefix.
+5. Create a GitHub Release with that same tag name; its body is the matching CHANGELOG entry.
+6. Clear all notebook cell outputs and `execution_count` values before committing.
+
+## Verifying notebook changes
+
+Each example is its own Julia environment:
+
+```bash
+cd TPM_Ryugu   # or TPM_Didymos
+julia --project=. -e 'using Pkg; Pkg.instantiate()'
+```
+
+A successful `Pkg.instantiate()` only proves dependencies resolve — actually run the
+notebook end-to-end (Jupyter or an IDE's notebook UI) before calling a migration done.
+
+## Git workflow
+
+- Work on a feature branch and open a PR; don't push directly to `main`.
+- Commit messages: Conventional Commits (`feat:`, `fix:`, `docs:`, ...), written in English.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ track a new version of the library they demonstrate.
 ## Versioning convention
 
 - Each entry below corresponds to a git tag named after the date the change was
-  merged (`YYYY-MM-DD`), e.g. [`2026-07-08`](https://github.com/Astroshaper/Astroshaper-examples/tree/2026-07-08).
+  merged (`vYYYY-MM-DD`), e.g. [`v2026-07-08`](https://github.com/Astroshaper/Astroshaper-examples/tree/v2026-07-08).
 - This repository is not a registered Julia package, so tags are not Semantic
   Versioning — they are just checkpoints you can check out to see the examples
   as they were for a specific past library version.
@@ -14,7 +14,7 @@ track a new version of the library they demonstrate.
   right now" is each example's own `Project.toml` `[compat]` entry, tracked in
   git history for that path.
 
-## 2026-07-08
+## v2026-07-08
 
 ### AsteroidThermoPhysicalModels.jl: v0.0.7 → v0.2.1
 
@@ -23,7 +23,7 @@ track a new version of the library they demonstrate.
   `SingleAsteroidOutputSpec`, `export_solution`), and moved shape loading to
   `AsteroidShapeModels.jl`.
 - Commit: [`23caad54`](https://github.com/Astroshaper/Astroshaper-examples/commit/23caad54a3335063d9c0b71bedf6e935331b5fbe) (PR [#18](https://github.com/Astroshaper/Astroshaper-examples/pull/18))
-- Tag: [`2026-07-08`](https://github.com/Astroshaper/Astroshaper-examples/tree/2026-07-08)
+- Tag: [`v2026-07-08`](https://github.com/Astroshaper/Astroshaper-examples/tree/v2026-07-08)
 - Previous state: tag [`v0.0.7-compatible`](https://github.com/Astroshaper/Astroshaper-examples/tree/v0.0.7-compatible)
 
 ## 2025-06-06


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` documenting this repo's conventions for AI coding agents: layout, the frozen `TPM_Kanamaru2021` example, the shared `plot_shape.jl` dependency gotcha, the migration checklist (notebook → README → CHANGELOG → tag → release), how to verify a notebook change, and the git/commit workflow.
- Switch date-based tags from bare `YYYY-MM-DD` to `vYYYY-MM-DD` for readability next to the legacy `vX.Y.Z-compatible` tags. The already-created `2026-07-08` tag/release (from #19) were renamed to `v2026-07-08` (tag `2026-07-08` deleted, release recreated under the new name), and `CHANGELOG.md` updated to match.

## Test plan
- [x] Confirmed `v2026-07-08` tag points at the same commit (`23caad54`) as the old `2026-07-08` tag did, and the old tag/release no longer exist
- [x] Reviewed `CHANGELOG.md` and `AGENTS.md` for consistency with the new naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)