### PR TITLE
docs: broaden `CHANGELOG.md` scope beyond library migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,13 +29,24 @@ plus a `README.md`.
    `README.md`.
 2. Update the root `README.md`'s `Compatible with: ...` line for that example, under
    `## Available Examples`.
-3. Add an entry to the root `CHANGELOG.md` (date, library, old → new version, commit hash,
-   PR number). See that file's "Versioning convention" section for the full policy and why
-   tags are dated rather than versioned.
-4. After merging, tag the merge commit with the merge date as `vYYYY-MM-DD` — this is not
+3. Clear all notebook cell outputs and `execution_count` values before committing.
+4. Follow the "Tagging a checkpoint" steps below.
+
+## Tagging a checkpoint
+
+`CHANGELOG.md` isn't limited to library migrations — it also covers other notable
+repository maintenance (tooling, conventions, restructuring). Whenever a change is
+worth a checkpoint:
+
+1. Add an entry to the root `CHANGELOG.md` (date, what changed, commit hash(es), PR
+   number(s)). See that file's "Versioning convention" section for the full policy and
+   why tags are dated rather than versioned.
+2. After merging, tag the merge commit with the merge date as `vYYYY-MM-DD` — this is not
    SemVer (this repo is not a registered package); the `v` is just a conventional prefix.
-5. Create a GitHub Release with that same tag name; its body is the matching CHANGELOG entry.
-6. Clear all notebook cell outputs and `execution_count` values before committing.
+   If several PRs land the same day, one tag at the end-of-day tip covering all of them is
+   fine — don't create a tag per PR.
+3. Create a GitHub Release with that same tag name; its body is the matching CHANGELOG
+   entry.
 
 ## Verifying notebook changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,39 @@
 # Changelog
 
-This file records when the example notebooks in this repository were updated to
-track a new version of the library they demonstrate.
+This file records notable changes to this repository: both updates that track a
+new version of a demonstrated library, and other maintenance (repository
+tooling, conventions, restructuring) worth a checkpoint.
 
 ## Versioning convention
 
 - Each entry below corresponds to a git tag named after the date the change was
   merged (`vYYYY-MM-DD`), e.g. [`v2026-07-08`](https://github.com/Astroshaper/Astroshaper-examples/tree/v2026-07-08).
 - This repository is not a registered Julia package, so tags are not Semantic
-  Versioning — they are just checkpoints you can check out to see the examples
-  as they were for a specific past library version.
+  Versioning — they are just checkpoints you can check out to see the repository
+  as it was at a notable point in time (a library-version migration or other
+  maintenance work).
 - The authoritative source for "which library version does this example target
   right now" is each example's own `Project.toml` `[compat]` entry, tracked in
   git history for that path.
+
+## v2026-07-09
+
+### Repository tooling: CHANGELOG, AGENTS.md, tag/release convention
+
+- Added this `CHANGELOG.md` as the append-only record of notable repository
+  changes, and folded the old top-level README `## Compatibility` section
+  into a `Compatible with: ...` line per example.
+- Added `AGENTS.md` documenting repository conventions for AI coding agents
+  (layout, the frozen `TPM_Kanamaru2021` example, the shared `plot_shape.jl`
+  dependency gotcha, the migration checklist, verification steps, and git
+  workflow).
+- Settled on `vYYYY-MM-DD` as the tag-naming convention for these checkpoints
+  (previously bare `YYYY-MM-DD`), and fixed the legacy v0.0.6→v0.0.7 entry
+  below to use its actual tag name (`v0.0.7-compatible`) as its heading.
+- Commits: PR [#19](https://github.com/Astroshaper/Astroshaper-examples/pull/19),
+  PR [#20](https://github.com/Astroshaper/Astroshaper-examples/pull/20),
+  PR [#21](https://github.com/Astroshaper/Astroshaper-examples/pull/21)
+- Tag: [`v2026-07-09`](https://github.com/Astroshaper/Astroshaper-examples/tree/v2026-07-09)
 
 ## v2026-07-08
 


### PR DESCRIPTION
## Summary
- `CHANGELOG.md` previously scoped itself to library-version migrations only. Broaden it to cover any notable repository maintenance, since tags/releases are now also being cut for tooling changes (e.g. the already-tagged `v2026-07-09`, which added `CHANGELOG.md`/`AGENTS.md` themselves — see PRs #19, #20, #21).
- Add the `v2026-07-09` CHANGELOG entry retroactively for that checkpoint.
- Update `AGENTS.md`'s checklist: split the notebook-editing steps from a generic "Tagging a checkpoint" section so both migration and non-migration changes follow the same CHANGELOG → tag → release steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)